### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Cppcheck.yaml
+++ b/.github/workflows/Cppcheck.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
           
       - name: Check C++ code
-        uses: deep5050/cppcheck-action@main
+        uses: deep5050/cppcheck-action@v3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/GitHub Actions Version Updater.yaml
+++ b/.github/workflows/GitHub Actions Version Updater.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/Super-Linter.yaml
+++ b/.github/workflows/Super-Linter.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/flawfinder.yaml
+++ b/.github/workflows/flawfinder.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
           
       - name: Check C++ code
-        uses: deep5050/flawfinder-action@master
+        uses: deep5050/flawfinder-action@1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ...


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[deep5050/cppcheck-action](https://github.com/deep5050/cppcheck-action)** published a new release [v3.0](https://github.com/deep5050/cppcheck-action/releases/tag/v3.0) on 2021-04-16T16:23:13Z
* **[deep5050/flawfinder-action](https://github.com/deep5050/flawfinder-action)** published a new release [1.0](https://github.com/deep5050/flawfinder-action/releases/tag/1.0) on 2020-04-24T09:33:41Z
